### PR TITLE
Increase timeouts to 30 minutes (Close #2)

### DIFF
--- a/templates/quickstart-docker.template
+++ b/templates/quickstart-docker.template
@@ -813,7 +813,7 @@
                 "Handle": {
                     "Ref": "WaitHandle01"
                 },
-                "Timeout": "900"
+                "Timeout": "1800"
             }
         },
         "WaitHandle02": {
@@ -827,7 +827,7 @@
                 "Handle": {
                     "Ref": "WaitHandle02"
                 },
-                "Timeout": "900"
+                "Timeout": "1800"
             }
         },
         "WaitHandle03": {
@@ -841,7 +841,7 @@
                 "Handle": {
                     "Ref": "WaitHandle03"
                 },
-                "Timeout": "900"
+                "Timeout": "1800"
             }
         },
         "ControllerRole": {


### PR DESCRIPTION
Bootstrap, configure, and install times can vary widely between regions. They also rely on external networks for pulling docker images and installing packages. 15 minutes worked fine in eu-west-1 but reliably fails in ap-southeast-1 (installs take ~20 mintues). 30 minutes is generous and should cover all cases. If things complete faster then that then great. Now they have some time.
